### PR TITLE
Remove flake-utils in all templates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,36 +1,22 @@
 {
   "nodes": {
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-utils",
-        "type": "indirect"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670267727,
-        "narHash": "sha256-hUFAn5gjNHIBpLQT0CmqpuQjQwgWUm+D6aziGAYsDmw=",
+        "lastModified": 1671035992,
+        "narHash": "sha256-KvCBf0dIcKjCJrOblWalqerqdIvcvUzBM02LyeUwGmM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a5f661b80e4c163510a5013b585a040a5c7ef55e",
+        "rev": "d7e27ad47ab9c5218c23b53de31eb29d7d8b02ab",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,34 +1,45 @@
 {
-  outputs = { self, nixpkgs, flake-utils }: {
-    templates = {
-      go = {
-        path = ./go;
-        description = "Go starter template for Zero to Nix";
-      };
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+  };
 
-      javascript = {
-        path = ./javascript;
-        description = "JavaScript starter template for Zero to Nix";
-      };
-
-      python = {
-        path = ./python;
-        description = "Python starter template for Zero to Nix";
-      };
-
-      rust = {
-        path = ./rust;
-        description = "Rust starter template for Zero to Nix";
-      };
-    };
-  } // flake-utils.lib.eachDefaultSystem (system:
+  outputs = { self, nixpkgs }:
     let
-      pkgs = import nixpkgs { inherit system; };
-      exampleShells = import ./shell/example.nix { inherit pkgs; };
+      nameValuePair = name: value: { inherit name value; };
+      genAttrs = names: f: builtins.listToAttrs (map (n: nameValuePair n (f n)) names);
+      allSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: genAttrs allSystems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
     in
     {
-      devShells = {
-        inherit (exampleShells) example javascript python go rust multi;
+      devShells = forAllSystems ({ pkgs }:
+        let
+          exampleShells = import ./shell/example.nix { inherit pkgs; };
+        in
+        {
+          inherit (exampleShells) example javascript python go rust multi;
+        });
+      templates = {
+        go = {
+          path = ./go;
+          description = "Go starter template for Zero to Nix";
+        };
+
+        javascript = {
+          path = ./javascript;
+          description = "JavaScript starter template for Zero to Nix";
+        };
+
+        python = {
+          path = ./python;
+          description = "Python starter template for Zero to Nix";
+        };
+
+        rust = {
+          path = ./rust;
+          description = "Rust starter template for Zero to Nix";
+        };
       };
-    });
+    };
 }

--- a/go/.envrc
+++ b/go/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -1,0 +1,2 @@
+# Nix artifacts
+result

--- a/go/flake.lock
+++ b/go/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -37,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668457438,
-        "narHash": "sha256-F9XXbObS/VNJe/4EHv0BZrOxg6GrG8ETc4qloMRvxjI=",
+        "lastModified": 1671034666,
+        "narHash": "sha256-UBafqzvxP87kOSZPhvWmJjuTh7Lw1GdIYShY1IhskTs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a04b8a8cbbe426850008461c4a0ad13694cc1c85",
+        "rev": "f23251c93e53420d103f8a8cb338910e4c2e8a7a",
         "type": "github"
       },
       "original": {
@@ -52,7 +37,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs"
       }

--- a/go/flake.lock
+++ b/go/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671034666,
-        "narHash": "sha256-UBafqzvxP87kOSZPhvWmJjuTh7Lw1GdIYShY1IhskTs=",
+        "lastModified": 1671035992,
+        "narHash": "sha256-KvCBf0dIcKjCJrOblWalqerqdIvcvUzBM02LyeUwGmM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f23251c93e53420d103f8a8cb338910e4c2e8a7a",
+        "rev": "d7e27ad47ab9c5218c23b53de31eb29d7d8b02ab",
         "type": "github"
       },
       "original": {

--- a/go/flake.nix
+++ b/go/flake.nix
@@ -3,23 +3,28 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
-    flake-utils.url = "github:numtide/flake-utils";
     gitignore = {
       url = "github:hercules-ci/gitignore.nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, gitignore }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
+  outputs = { self, nixpkgs, gitignore }:
+    let
+      nameValuePair = name: value: { inherit name value; };
+      genAttrs = names: f: builtins.listToAttrs (map (n: nameValuePair n (f n)) names);
+      allSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: genAttrs allSystems (system: f {
         pkgs = import nixpkgs { inherit system; };
-      in
-      {
-        packages.default = pkgs.buildGoModule {
+      });
+    in
+    {
+      packages = forAllSystems ({ pkgs }: {
+        default = pkgs.buildGoModule {
           name = "zero-to-nix-go";
           src = gitignore.lib.gitignoreSource ./.;
           vendorSha256 = "sha256-fwJTg/HqDAI12mF1u/BlnG52yaAlaIMzsILDDZuETrI=";
         };
       });
+    };
 }

--- a/javascript/.envrc
+++ b/javascript/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/javascript/.gitignore
+++ b/javascript/.gitignore
@@ -1,3 +1,6 @@
+# JavaScript artifacts
 /node_modules/
 /dist/
+
+# Nix artifacts
 result

--- a/javascript/flake.lock
+++ b/javascript/flake.lock
@@ -1,27 +1,12 @@
 {
   "nodes": {
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668457438,
-        "narHash": "sha256-F9XXbObS/VNJe/4EHv0BZrOxg6GrG8ETc4qloMRvxjI=",
+        "lastModified": 1671034666,
+        "narHash": "sha256-UBafqzvxP87kOSZPhvWmJjuTh7Lw1GdIYShY1IhskTs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a04b8a8cbbe426850008461c4a0ad13694cc1c85",
+        "rev": "f23251c93e53420d103f8a8cb338910e4c2e8a7a",
         "type": "github"
       },
       "original": {
@@ -32,7 +17,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/javascript/flake.lock
+++ b/javascript/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671034666,
-        "narHash": "sha256-UBafqzvxP87kOSZPhvWmJjuTh7Lw1GdIYShY1IhskTs=",
+        "lastModified": 1671035992,
+        "narHash": "sha256-KvCBf0dIcKjCJrOblWalqerqdIvcvUzBM02LyeUwGmM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f23251c93e53420d103f8a8cb338910e4c2e8a7a",
+        "rev": "d7e27ad47ab9c5218c23b53de31eb29d7d8b02ab",
         "type": "github"
       },
       "original": {

--- a/javascript/flake.nix
+++ b/javascript/flake.nix
@@ -3,38 +3,39 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
-    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs =
-    { self
-    , nixpkgs
-    , flake-utils
-    }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs = { self, nixpkgs }:
     let
-      pkgs = import nixpkgs { inherit system; };
+      nameValuePair = name: value: { inherit name value; };
+      genAttrs = names: f: builtins.listToAttrs (map (n: nameValuePair n (f n)) names);
+      allSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: genAttrs allSystems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
     in
     {
-      packages.default = pkgs.stdenv.mkDerivation {
-        name = "zero-to-nix-javascript";
+      packages = forAllSystems ({ pkgs }: {
+        default = pkgs.stdenv.mkDerivation {
+          name = "zero-to-nix-javascript";
 
-        buildInputs = [
-          pkgs.nodePackages.pnpm
-          pkgs.nodejs-18_x
-        ];
+          buildInputs = [
+            pkgs.nodePackages.pnpm
+            pkgs.nodejs-18_x
+          ];
 
-        src = self;
+          src = ./.;
 
-        buildPhase = ''
-          pnpm install
-          pnpm run build
-        '';
+          buildPhase = ''
+            pnpm install
+            pnpm run build
+          '';
 
-        installPhase = ''
-          mkdir $out
-          cp dist/index.html $out
-        '';
-      };
-    });
+          installPhase = ''
+            mkdir $out
+            cp dist/index.html $out
+          '';
+        };
+      });
+    };
 }

--- a/python/.envrc
+++ b/python/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,2 +1,6 @@
+# Python artifacts
 /*.egg-info/
 /__pycache__/
+
+# Nix artifacts
+result

--- a/python/flake.lock
+++ b/python/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668725244,
-        "narHash": "sha256-dbUN+o2zB2pvbYBbKm7QtirOZR2B8e76N+3G2c7zl8M=",
+        "lastModified": 1671035992,
+        "narHash": "sha256-KvCBf0dIcKjCJrOblWalqerqdIvcvUzBM02LyeUwGmM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e894d912810459b549b157d11183a32deb257d88",
+        "rev": "d7e27ad47ab9c5218c23b53de31eb29d7d8b02ab",
         "type": "github"
       },
       "original": {

--- a/python/flake.lock
+++ b/python/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1668725244,
@@ -32,7 +17,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/rust/.envrc
+++ b/rust/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/rust/flake.lock
+++ b/rust/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671035594,
-        "narHash": "sha256-P3WZH5gRmAha8CITMQWWIsP18YEw8xEUAndCdpA8EXg=",
+        "lastModified": 1671035992,
+        "narHash": "sha256-KvCBf0dIcKjCJrOblWalqerqdIvcvUzBM02LyeUwGmM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "634a33fa83239fdf084a7b664f67e25b9dd92367",
+        "rev": "d7e27ad47ab9c5218c23b53de31eb29d7d8b02ab",
         "type": "github"
       },
       "original": {

--- a/rust/flake.lock
+++ b/rust/flake.lock
@@ -2,21 +2,6 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
@@ -32,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668457438,
-        "narHash": "sha256-F9XXbObS/VNJe/4EHv0BZrOxg6GrG8ETc4qloMRvxjI=",
+        "lastModified": 1671035594,
+        "narHash": "sha256-P3WZH5gRmAha8CITMQWWIsP18YEw8xEUAndCdpA8EXg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a04b8a8cbbe426850008461c4a0ad13694cc1c85",
+        "rev": "634a33fa83239fdf084a7b664f67e25b9dd92367",
         "type": "github"
       },
       "original": {
@@ -63,22 +48,21 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1668393806,
-        "narHash": "sha256-ew2bYm8z7CWKA2qcTuCk4/xEY4uG3WAloTczICe7gbc=",
+        "lastModified": 1670985057,
+        "narHash": "sha256-QfLKTSQUc82HXeIipukznInr5IXXgK1YKm5dplm1Q+A=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "219feff2b874bf6f3d18214a8ed3f360fe067759",
+        "rev": "da99b6227d450438d53ba4b0cf64e43ad2e93e58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The flake-utils lib is a nice helper but it adds more mystery than it removes. This PR replaces it with plain old Nix functions. To test, I've successfully built and run the packages in each template.